### PR TITLE
Remove numba dependency/extra for quaternion.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "atlas-commons>=0.1.4",
         "click>=7.0",
         "numpy>=1.15.0",
-        "numpy-quaternion[numba]>=2021.11.4.15.26.3",
+        "numpy-quaternion>=2021.11.4.15.26.3",
         "scipy>=1.4.1",
         "voxcell>=3.0.0",
     ],


### PR DESCRIPTION
The docs to numpy-quaterion
(https://quaternion.readthedocs.io/en/latest) state:

> However, certain advanced functions in this package (including squad,
> mean_rotor_in_intrinsic_metric, integrate_angular_velocity, and related
> functions) require scipy and can automatically use numba.

Thus I think it is save to remove this dependency extra that requires a
LLVM ≤ 11.
