### PR TITLE
Cleanup

### DIFF
--- a/atlas_direction_vectors/algorithms/utils.py
+++ b/atlas_direction_vectors/algorithms/utils.py
@@ -1,10 +1,9 @@
 """Low-level tools for the computation of direction vectors"""
 
 import numpy as np  # type: ignore
-import quaternion  # type: ignore
-from atlas_commons.utils import FloatArray, NumericArray, normalize, zero_to_nan
-from scipy.ndimage.filters import gaussian_filter  # type: ignore
-from scipy.ndimage.morphology import generate_binary_structure  # type: ignore
+from atlas_commons.utils import FloatArray, NumericArray, normalize
+from scipy.ndimage import gaussian_filter  # type: ignore
+from scipy.ndimage import generate_binary_structure  # type: ignore
 from scipy.signal import correlate  # type: ignore
 
 
@@ -37,24 +36,6 @@ def compute_blur_gradient(scalar_field: FloatArray, gaussian_stddev=3.0) -> Floa
     gradient = np.moveaxis(gradient, 0, -1)
     normalize(gradient)
     return gradient
-
-
-def quaternion_to_vector(quaternion_field: FloatArray) -> FloatArray:
-    """
-    Rotate the reference vector (0.0, 1.0, 0.0) by the quaternions of `quaternion_field`.
-
-    Arguments:
-        quaternion_field: float array of shape (W, L, D, 4),
-            the 4 quaternion coordinates are given by the last axis;
-            in other words, it is a quaternionic vector field on a 3D volume.
-
-    Returns:
-        A 3D vector field on a 3D volume under the form of a numpy.ndarray of shape
-        (W, L, D, 3).
-    """
-    quaternion_field = quaternion_field.copy()
-    zero_to_nan(quaternion_field)
-    return quaternion.rotate_vectors(quaternion.from_float_array(quaternion_field), (0.0, 1.0, 0.0))
 
 
 def _quaternion_from_vectors(  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         "atlas-commons>=0.1.4",
         "click>=7.0",
         "numpy>=1.15.0",
-        "numpy-quaternion[numba]>=2021.11.4.15.26.3",
         "scipy>=1.4.1",
         "voxcell>=3.0.0",
     ],

--- a/tests/algorithms/test_utils.py
+++ b/tests/algorithms/test_utils.py
@@ -33,26 +33,6 @@ def test_compute_blur_gradient():
         tested.compute_blur_gradient(scalar_field, 0.1)
 
 
-class Test_quaternion_to_vector:
-    def test_single_vector(self):
-        vectors = tested.quaternion_to_vector(np.array([1.0, 0.0, 0.0, 0.0]))
-        npt.assert_almost_equal(vectors, [0.0, 1.0, 0.0])
-        vectors = tested.quaternion_to_vector(np.array([1.0, 0.0, 0.0, -1.0]))
-        npt.assert_almost_equal(vectors, [1.0, 0.0, 0.0])
-        vectors = tested.quaternion_to_vector(np.array([1.0, 1.0, 0.0, 0.0]))
-        npt.assert_almost_equal(vectors, [0, 0, 1])
-        vectors = tested.quaternion_to_vector(np.array([1.0, 1.0, 0.0, 0.0]) * 2.0)
-        npt.assert_almost_equal(vectors, [0, 0, 1])
-
-    def test_identity_quaternion_gives_y(self):
-        vectors = tested.quaternion_to_vector(np.array([[[1.0, 0.0, 0.0, 0.0]]]))
-        npt.assert_almost_equal(vectors, [[[0.0, 1.0, 0.0]]])
-
-    def test_invert_quaternion_gives_negative_y(self):
-        vectors = tested.quaternion_to_vector(np.array([[[0.0, 1.0, 0.0, 0.0]]]))
-        npt.assert_almost_equal(vectors, [[[0, -1, 0]]])
-
-
 class Test_vector_to_quaternion:
     @pyt.mark.xfail
     def test_long_vector_gives_same_quat(self):
@@ -60,17 +40,6 @@ class Test_vector_to_quaternion:
             tested.vector_to_quaternion(np.array([[[1.0, 0.0, 0.0]]])),
             tested.vector_to_quaternion(np.array([[[5, 0, 0]]])),
         )
-
-
-def test_quaternion_converters_consistency():
-    vectors = normalized(
-        np.array([[1.0, 0.0, 0.0], [1.0, 2.0, 3.0], [3.0, 2.0, 3.0], [0.0, 2.0, 1.0]])
-    )
-    quaternions = tested.vector_to_quaternion(vectors)
-    npt.assert_almost_equal(tested.quaternion_to_vector(quaternions), vectors, decimal=3)
-    vectors = normalized(np.array([[np.nan, np.nan, np.nan], [np.nan, np.nan, np.nan]]))
-    quaternions = tested.vector_to_quaternion(vectors)
-    npt.assert_almost_equal(tested.quaternion_to_vector(quaternions), vectors, decimal=3)
 
 
 def test_compute_boundary():


### PR DESCRIPTION
* remove `quaternion_to_vector`, saves us a dependency, wasn't used in the package
* cleanup scipy warnings