### PR TITLE
Update condition for error from layer queries. Fix #16

### DIFF
--- a/atlas_direction_vectors/algorithms/layer_based_direction_vectors.py
+++ b/atlas_direction_vectors/algorithms/layer_based_direction_vectors.py
@@ -285,9 +285,9 @@ def compute_layered_region_direction_vectors(
 
     # example: ids[ids!=0] -> [1, 2, 3], layers -> [1, 2], external_id -> 3
     *layers, external_id = ids[ids != 0]
-    if len(ids[ids != 0]) != len(layer_queries):
+    if len(ids[ids != 0]) > len(layer_queries):
         raise AtlasDirectionVectorsError(
-            f"Layer region ids were not correctly assigned from the layer_queries\n"
+            f"Layer region ids cannot be  all labeled from the layer_queries\n"
             f"Layered region ids: {ids}\n"
             f"layer queries: {layer_queries}"
         )

--- a/atlas_direction_vectors/algorithms/layer_based_direction_vectors.py
+++ b/atlas_direction_vectors/algorithms/layer_based_direction_vectors.py
@@ -287,7 +287,7 @@ def compute_layered_region_direction_vectors(
     *layers, external_id = ids[ids != 0]
     if len(ids[ids != 0]) > len(layer_queries):
         raise AtlasDirectionVectorsError(
-            f"Layer region ids cannot be  all labeled from the layer_queries\n"
+            f"Layer region ids cannot be all labeled from the layer_queries\n"
             f"Layered region ids: {ids}\n"
             f"layer queries: {layer_queries}"
         )


### PR DESCRIPTION
Adapt cerebellum orientation field computation to the presence/absence of Purkinje Layer.
The Purkinje layer is not labeled in the annotation atlas by default. Its absence should not prevent the creation of orientation field. However a test of the number on the number of layers against the number of queries prevents its execution.
I propose to change this test to take into account the use cases where the annotation atlas does not have Purkinje layer.