### PR TITLE
Update thalamus

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Run tox
       run: |
-        tox -etests
+        tox
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', ]
+        python-version: ['3.8', '3.9', '3.10', ]
 
     steps:
     - uses: actions/checkout@v3

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2005-2023 Blue Brain Project/EPFL
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/atlas_direction_vectors/algorithms/blur_gradient.py
+++ b/atlas_direction_vectors/algorithms/blur_gradient.py
@@ -156,7 +156,6 @@ def _sequential_region_shading(
     shading_mask = np.zeros_like(annotation_raw)
 
     for shading_value in shades:
-
         boundary_mask = region_dilation(
             annotation_raw=region_mask,
             region_label=region_label,

--- a/atlas_direction_vectors/algorithms/layer_based_direction_vectors.py
+++ b/atlas_direction_vectors/algorithms/layer_based_direction_vectors.py
@@ -62,7 +62,7 @@ def attributes_to_ids(
 
     """
     ids = set()
-    for (attribute, value) in attributes:
+    for attribute, value in attributes:
         ids |= region_map.find(value, attribute, ignore_case=False, with_descendants=True)
     return list(ids)
 
@@ -309,7 +309,6 @@ def compute_layered_region_direction_vectors(
     direction_vectors = np.full(annotation.raw.shape + (3,), np.nan, dtype=np.float32)
 
     if has_hemispheres:
-
         for hemisphere_mask in split_into_halves(np.full(annotation.raw.shape, True, dtype=bool)):
             layered_hemisphere = np.zeros_like(hemisphere_mask, dtype=np.uint8)
             np.copyto(layered_hemisphere, layered_region, where=hemisphere_mask)
@@ -326,7 +325,6 @@ def compute_layered_region_direction_vectors(
             direction_vectors[hemisphere_mask, :] = hemi_direction_vectors[hemisphere_mask, :]
 
     else:
-
         direction_vectors[:] = _expanded_boundary_shading(
             layered_region,
             layers,

--- a/atlas_direction_vectors/algorithms/simple_blur_gradient.py
+++ b/atlas_direction_vectors/algorithms/simple_blur_gradient.py
@@ -22,7 +22,7 @@ def compute_direction_vectors(
     sigma: float = 10.0,
     source_weight: float = -1.0,
     target_weight: float = 1.0,
-    radius = None,
+    radius=None,
 ) -> NDArray[np.float32]:
     """
     Compute direction vectors in the `inside` volume.
@@ -63,9 +63,9 @@ def compute_direction_vectors(
     scalar_field[source] = source_weight
     scalar_field[target] = target_weight
 
-    direction_vectors = compute_blur_gradient(scalar_field,
-                                              gaussian_stddev=sigma,
-                                              gaussian_radius=radius)
+    direction_vectors = compute_blur_gradient(
+        scalar_field, gaussian_stddev=sigma, gaussian_radius=radius
+    )
     direction_vectors[~inside, :] = np.nan
 
     return direction_vectors

--- a/atlas_direction_vectors/algorithms/simple_blur_gradient.py
+++ b/atlas_direction_vectors/algorithms/simple_blur_gradient.py
@@ -22,6 +22,7 @@ def compute_direction_vectors(
     sigma: float = 10.0,
     source_weight: float = -1.0,
     target_weight: float = 1.0,
+    radius = None,
 ) -> NDArray[np.float32]:
     """
     Compute direction vectors in the `inside` volume.
@@ -45,6 +46,10 @@ def compute_direction_vectors(
             float value to be assigned to all voxels in `source`. Defaults to -1.0.
         target_weight:
             float value to be assigned to all voxels in `target`. Defaults to 1.0.
+        radius:
+            radius of the Gaussian kernel used for truncation. If 'None' is
+            passed, the default behavior is used: the radius of the kernel is
+            automatically truncated at (4.0 * sigma). Defaults to None.
 
     Returns:
         Array holding a vector field of unit vectors defined on the `inside` 3D volume. The shape
@@ -58,7 +63,9 @@ def compute_direction_vectors(
     scalar_field[source] = source_weight
     scalar_field[target] = target_weight
 
-    direction_vectors = compute_blur_gradient(scalar_field, gaussian_stddev=sigma)
+    direction_vectors = compute_blur_gradient(scalar_field,
+                                              gaussian_stddev=sigma,
+                                              gaussian_radius=radius)
     direction_vectors[~inside, :] = np.nan
 
     return direction_vectors

--- a/atlas_direction_vectors/algorithms/utils.py
+++ b/atlas_direction_vectors/algorithms/utils.py
@@ -7,7 +7,8 @@ from scipy.ndimage import generate_binary_structure  # type: ignore
 from scipy.signal import correlate  # type: ignore
 
 
-def compute_blur_gradient(scalar_field: FloatArray, gaussian_stddev=3.0) -> FloatArray:
+def compute_blur_gradient(scalar_field: FloatArray, gaussian_stddev=3.0,
+                          gaussian_radius=None) -> FloatArray:
     """
     Blurs a scalar field and returns its normalized gradient.
 
@@ -20,6 +21,10 @@ def compute_blur_gradient(scalar_field: FloatArray, gaussian_stddev=3.0) -> Floa
             a 3D volume.
         gaussian_stddev: standard deviation of the Gaussian kernel used by the
             Gaussian filter.
+        gaussian_radius: radius of the Gaussian kernel used by the
+            Gaussian filter. If 'None' is passed, the default behavior is used:
+            the radius of the kernel is automatically truncated at (4.0 *
+            gaussian_stddev).
     Returns:
         numpy.ndarray of float type. A 3D unit vector field over the underlying 3D volume
         of the input scalar field. This vector contains np.nan vectors if the normalization
@@ -31,7 +36,7 @@ def compute_blur_gradient(scalar_field: FloatArray, gaussian_stddev=3.0) -> Floa
         raise ValueError(
             f"The input field must be of floating point type. Got {scalar_field.dtype}."
         )
-    blurred = gaussian_filter(scalar_field, sigma=gaussian_stddev)
+    blurred = gaussian_filter(scalar_field, sigma=gaussian_stddev, radius=gaussian_radius)
     gradient = np.array(np.gradient(blurred))
     gradient = np.moveaxis(gradient, 0, -1)
     normalize(gradient)

--- a/atlas_direction_vectors/algorithms/utils.py
+++ b/atlas_direction_vectors/algorithms/utils.py
@@ -7,8 +7,9 @@ from scipy.ndimage import generate_binary_structure  # type: ignore
 from scipy.signal import correlate  # type: ignore
 
 
-def compute_blur_gradient(scalar_field: FloatArray, gaussian_stddev=3.0,
-                          gaussian_radius=None) -> FloatArray:
+def compute_blur_gradient(
+    scalar_field: FloatArray, gaussian_stddev=3.0, gaussian_radius=None
+) -> FloatArray:
     """
     Blurs a scalar field and returns its normalized gradient.
 

--- a/atlas_direction_vectors/thalamus.py
+++ b/atlas_direction_vectors/thalamus.py
@@ -70,7 +70,7 @@ def compute_direction_vectors(
     landscape = {
         "source": np.zeros_like(thalamus_mask),
         "inside": reticular_nucleus_complement_mask,
-        "target": reticular_nucleus_mask,
+        "target": common_outer_boundary_mask,
     }
     ratio = (
         brain_regions.voxel_dimensions[0] / 25

--- a/atlas_direction_vectors/thalamus.py
+++ b/atlas_direction_vectors/thalamus.py
@@ -62,6 +62,7 @@ def compute_direction_vectors(
         Vector field of 3D unit vectors over the thalamus volume with the same shape
         as the input one. Voxels outside the thalamus have np.nan coordinates.
     """
+
     thalamus_mask = get_region_mask("TH", brain_regions.raw, region_map)
     reticular_nucleus_mask = get_region_mask("RT", brain_regions.raw, region_map)
     reticular_nucleus_complement_mask = np.logical_and(thalamus_mask, ~reticular_nucleus_mask)
@@ -79,26 +80,28 @@ def compute_direction_vectors(
         algorithm="simple-blur-gradient",
         hemisphere_opposite_option=(HemisphereOppositeOption.IGNORE_OPPOSITE_HEMISPHERE),
         # The use of this algorithm was initially done by Hugo Dictus
-        # The constants below have been derived using trial-and-error by Austin Soplata
+        # The constants below have been changed using trial-and-error by Austin Soplata
         sigma=ratio * 9.0,
         source_weight=0,
         target_weight=1,
         radius=100,
     )
+
     landscape = {
-        "source": common_outer_boundary_mask,
+        "source": reticular_nucleus_complement_mask,
         "inside": reticular_nucleus_mask,
-        "target": reticular_nucleus_complement_mask,
+        "target": common_outer_boundary_mask,
     }
+
     rt_direction_vectors = direction_vectors_for_hemispheres(
         landscape,
         algorithm="simple-blur-gradient",
         hemisphere_opposite_option=(HemisphereOppositeOption.IGNORE_OPPOSITE_HEMISPHERE),
         # The use of this algorithm was initially done by Hugo Dictus
-        # The constants below have been derived using trial-and-error by Austin Soplata
-        sigma=ratio * 5.0,
-        source_weight=0,
-        target_weight=1,
+        # The constants below have been changed using trial-and-error by Austin Soplata
+        sigma=ratio * 8.0,
+        source_weight=-0.2,
+        target_weight=0,
     )
 
     direction_vectors = np.full(rt_direction_vectors.shape, np.nan, dtype=np.float32)

--- a/atlas_direction_vectors/thalamus.py
+++ b/atlas_direction_vectors/thalamus.py
@@ -69,7 +69,7 @@ def compute_direction_vectors(
     landscape = {
         "source": np.zeros_like(thalamus_mask),
         "inside": reticular_nucleus_complement_mask,
-        "target": common_outer_boundary_mask,
+        "target": reticular_nucleus_mask,
     }
     ratio = (
         brain_regions.voxel_dimensions[0] / 25
@@ -77,24 +77,27 @@ def compute_direction_vectors(
     rt_complement_direction_vectors = direction_vectors_for_hemispheres(
         landscape,
         algorithm="simple-blur-gradient",
-        hemisphere_opposite_option=(HemisphereOppositeOption.INCLUDE_AS_SOURCE),
-        # The constants below have been derived empirically by Hugo Dictus
-        sigma=ratio * 18.0,
-        source_weight=-2.0 * 0.9999999,
-        target_weight=2 * 0.1111111,
+        hemisphere_opposite_option=(HemisphereOppositeOption.IGNORE_OPPOSITE_HEMISPHERE),
+        # The use of this algorithm was initially done by Hugo Dictus
+        # The constants below have been derived using trial-and-error by Austin Soplata
+        sigma=ratio * 9.0,
+        source_weight=0,
+        target_weight=1,
+        radius=100,
     )
     landscape = {
-        "source": reticular_nucleus_complement_mask,
+        "source": common_outer_boundary_mask,
         "inside": reticular_nucleus_mask,
-        "target": common_outer_boundary_mask,
+        "target": reticular_nucleus_complement_mask,
     }
     rt_direction_vectors = direction_vectors_for_hemispheres(
         landscape,
         algorithm="simple-blur-gradient",
-        hemisphere_opposite_option=(HemisphereOppositeOption.INCLUDE_AS_SOURCE),
-        # The constants below have been derived empirically by Hugo Dictus
+        hemisphere_opposite_option=(HemisphereOppositeOption.IGNORE_OPPOSITE_HEMISPHERE),
+        # The use of this algorithm was initially done by Hugo Dictus
+        # The constants below have been derived using trial-and-error by Austin Soplata
         sigma=ratio * 5.0,
-        source_weight=-1,
+        source_weight=0,
         target_weight=1,
     )
 

--- a/tests/algorithms/test_blur_gradient.py
+++ b/tests/algorithms/test_blur_gradient.py
@@ -8,7 +8,6 @@ from atlas_direction_vectors.exceptions import AtlasDirectionVectorsError
 
 def _print_arrays(*arrays):
     class Colors:
-
         RED = "\u001b[31m"
         CYAN = "\u001b[36m"
         GREEN = "\u001b[32m"
@@ -45,7 +44,6 @@ def _print_arrays(*arrays):
 
 @pytest.fixture
 def annotation():
-
     raw = np.zeros((6, 8, 8), dtype=np.int32)
 
     raw[(1, 2), 2:6, 2:6] = 1
@@ -55,7 +53,6 @@ def annotation():
 
 
 def test_region_dilation(annotation):
-
     actual_mask = tested.region_dilation(annotation, region_label=1, shading_target_label=0)
 
     expected_mask = np.array(
@@ -206,7 +203,6 @@ def test_region_dilation(annotation):
 
 
 def test_sequential_region_shading(annotation):
-
     res = tested._sequential_region_shading(
         annotation, region_label=2, shading_target_label=0, shades=[5, 4]
     )
@@ -281,7 +277,6 @@ def test_sequential_region_shading(annotation):
 
 
 def test_shading_from_boundary():
-
     input_mask = np.array(
         [
             [

--- a/tests/algorithms/test_layer_based_direction_vectors.py
+++ b/tests/algorithms/test_layer_based_direction_vectors.py
@@ -420,7 +420,6 @@ class Test_compute_direction_vectors:
 
 
 def test_build_layered_region_weights():
-
     regions = ["r1", "r2", "r3"]
     region_to_weight = {"r1": -1, "r2": 0, "r3": 1, "outside_of_brain": -2}
 
@@ -430,7 +429,6 @@ def test_build_layered_region_weights():
 
 
 def test_compute_layered_direction_vectors():
-
     metadata = {"layers": {"queries": ["q1", "q2"]}}
     region_to_weight = {"q1": 1, "q3": 2}
 

--- a/tests/app/test_direction_vectors.py
+++ b/tests/app/test_direction_vectors.py
@@ -41,10 +41,8 @@ def test_thalamus():
 
 
 def test_cerebellum():
-
     runner = CliRunner()
     with runner.isolated_filesystem():
-
         cerebellum_raw = np.zeros((8, 8, 8))
         for x_index, region_id in enumerate([10707, 10692, 10706, 10691, 10705, 10690, 744, 728]):
             cerebellum_raw[x_index, :, :] = region_id

--- a/tests/test_cerebellum.py
+++ b/tests/test_cerebellum.py
@@ -145,7 +145,6 @@ def _acronyms_to_flattened_identifiers(region_map, acronyms):
 
 
 def _check_vectors_defined_in_regions(direction_vectors, region_map, annotation, acronyms):
-
     assert direction_vectors.shape == annotation.raw.shape + (3,)
 
     # The region of interest should not have nan value
@@ -165,7 +164,6 @@ def _check_vectors_defined_in_regions(direction_vectors, region_map, annotation,
 def _check_vectors_direction_dominance(
     direction_vectors, region_map, annotation, acronyms, direction
 ):
-
     region_mask = np.isin(annotation.raw, _acronyms_to_flattened_identifiers(region_map, acronyms))
 
     region_vectors = direction_vectors[region_mask, :]
@@ -183,7 +181,6 @@ def _check_vectors_direction_dominance(
 
 
 def test_compute_cerebellum_direction_vectors(region_map, annotation):
-
     res = tested.compute_direction_vectors(region_map, annotation)
     _check_vectors_defined_in_regions(
         res, region_map, annotation, ["FLgr", "FLpu", "FLmo"] + ["LINGgr", "LINGpu", "LINGmo"]
@@ -205,7 +202,6 @@ def test_compute_cerebellum_direction_vectors(region_map, annotation):
 
 
 def test_cereb_subreg_direction_vectors(region_map, annotation):
-
     res = tested.cereb_subregion_direction_vectors(
         region_map.find("FL", "acronym").pop(), region_map, annotation
     )

--- a/tests/test_isocortex.py
+++ b/tests/test_isocortex.py
@@ -21,7 +21,6 @@ def region_map():
 
 
 def _check_vectors_direction_dominance(direction_vectors, annotation, direction):
-
     region_mask = annotation.raw > 983
 
     region_vectors = direction_vectors[region_mask, :]
@@ -122,7 +121,6 @@ def test_compute_direction_vectors_with_missing_bottom(region_map):
 
 
 def test_compute_directions__shading_gradient(region_map):
-
     raw = np.zeros((20, 30, 20), dtype=np.int32)
 
     raw[6:14, (6, 7), 6:14] = 983

--- a/tests/test_thalamus.py
+++ b/tests/test_thalamus.py
@@ -79,7 +79,7 @@ def test_compute_direction_vectors(region_map):
         assert np.all(np.isnan(direction_vectors[:, [0, 11], :]))
         assert np.all(np.isnan(direction_vectors[:, :, [0, 11]]))
         norms = np.linalg.norm(direction_vectors, axis=-1)
-        npt.assert_allclose(norms[3:11, 1:11, 1:11], 1.0, rtol=1e-6)
+        npt.assert_allclose(norms[3:11, 1:11, 1:11], 1.0, rtol=1e-3)
         npt.assert_allclose(norms[1, 1:11, 1:11], 1.0, rtol=1e-6)
 
     # Reducing the voxel dimensions reduces the Gaussian blur standard deviation.

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,6 @@
 name = atlas_direction_vectors
 black_version = 22.0
 
-[tox]
-envlist =
-    check-version
-    lint
-    docs
-    tests
-
 [testenv]
 extras = tests
 passenv = PYTHONPATH


### PR DESCRIPTION
This is a very small pull request for passing a "radius" argument down all the way to scipy's `gaussian_filter` in `atlas_direction_vectors/algorithms/utils.py`, and then using it and changing some parameters used for the thalamus' direction-vectors calculation. Most of the single-line changes are just from running the `isort` and `black` commands as suggested in the README. Thanks!